### PR TITLE
remove respawn feature

### DIFF
--- a/src/Enemies/Fireball.java
+++ b/src/Enemies/Fireball.java
@@ -28,9 +28,6 @@ public class Fireball extends Enemy {
         // how long the fireball will exist for before disappearing
         existenceTimer.setWaitTime(existenceTime);
 
-        // this enemy will not respawn after it has been removed
-        isRespawnable = false;
-
         initialize();
     }
 

--- a/src/Level/Camera.java
+++ b/src/Level/Camera.java
@@ -92,9 +92,6 @@ public class Camera extends Rectangle {
                 }
             } else if (enemy.getMapEntityStatus() == MapEntityStatus.ACTIVE) {
                 enemy.setMapEntityStatus(MapEntityStatus.INACTIVE);
-                if (enemy.isRespawnable()) {
-                    enemy.initialize();
-                }
             } else if (enemy.getMapEntityStatus() == MapEntityStatus.REMOVED) {
                 map.getEnemies().remove(i);
             }
@@ -115,9 +112,6 @@ public class Camera extends Rectangle {
                 }
             } else if (enhancedMapTile.getMapEntityStatus() == MapEntityStatus.ACTIVE) {
                 enhancedMapTile.setMapEntityStatus(MapEntityStatus.INACTIVE);
-                if (enhancedMapTile.isRespawnable()) {
-                    enhancedMapTile.initialize();
-                }
             } else if (enhancedMapTile.getMapEntityStatus() == MapEntityStatus.REMOVED) {
                 map.getEnhancedMapTiles().remove(i);
             }
@@ -138,9 +132,6 @@ public class Camera extends Rectangle {
                 }
             } else if (npc.getMapEntityStatus() == MapEntityStatus.ACTIVE) {
                 npc.setMapEntityStatus(MapEntityStatus.INACTIVE);
-                if (npc.isRespawnable()) {
-                    npc.initialize();
-                }
             } else if (npc.getMapEntityStatus() == MapEntityStatus.REMOVED) {
                 map.getNPCs().remove(i);
             }

--- a/src/Level/MapEntity.java
+++ b/src/Level/MapEntity.java
@@ -11,10 +11,7 @@ import java.util.HashMap;
 public class MapEntity extends GameObject {
     protected MapEntityStatus mapEntityStatus = MapEntityStatus.ACTIVE;
 
-    // if true, if entity goes out of the camera's update range, and then ends up back in range, the entity will "respawn" back to its starting parameters
-    protected boolean isRespawnable = true;
-
-    // if true, entity cannot go out of camera's update range
+    // if true, entity will continue to be updated even if off camera
     protected boolean isUpdateOffScreen = false;
 
     public MapEntity(float x, float y, SpriteSheet spriteSheet, String startingAnimation) {
@@ -53,14 +50,6 @@ public class MapEntity extends GameObject {
 
     public void setMapEntityStatus(MapEntityStatus mapEntityStatus) {
         this.mapEntityStatus = mapEntityStatus;
-    }
-
-    public boolean isRespawnable() {
-        return isRespawnable;
-    }
-
-    public void setIsRespawnable(boolean isRespawnable) {
-        this.isRespawnable = isRespawnable;
     }
 
     public boolean isUpdateOffScreen() {


### PR DESCRIPTION
There was a "respawn" feature on entities that wasn't needed because enemies can be "respawned" at any time through adding entities directly to a map's entity list... and the feature didn't quite work correctly and caused some oddities like entities appearing out of thin air