### PR TITLE
Convert animation delay time from milliseconds to number of frames

### DIFF
--- a/src/Enemies/BugEnemy.java
+++ b/src/Enemies/BugEnemy.java
@@ -99,23 +99,23 @@ public class BugEnemy extends Enemy {
     public HashMap<String, Frame[]> loadAnimations(SpriteSheet spriteSheet) {
         return new HashMap<String, Frame[]>() {{
             put("WALK_LEFT", new Frame[] {
-                    new FrameBuilder(spriteSheet.getSprite(0, 0), 100)
+                    new FrameBuilder(spriteSheet.getSprite(0, 0), 8)
                             .withScale(2)
                             .withBounds(6, 6, 12, 7)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(0, 1), 100)
+                    new FrameBuilder(spriteSheet.getSprite(0, 1), 8)
                             .withScale(2)
                             .withBounds(6, 6, 12, 7)
                             .build()
             });
 
             put("WALK_RIGHT", new Frame[] {
-                    new FrameBuilder(spriteSheet.getSprite(0, 0), 100)
+                    new FrameBuilder(spriteSheet.getSprite(0, 0), 8)
                             .withScale(2)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .withBounds(6, 6, 12, 7)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(0, 1), 100)
+                    new FrameBuilder(spriteSheet.getSprite(0, 1), 8)
                             .withScale(2)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .withBounds(6, 6, 12, 7)

--- a/src/Enemies/DinosaurEnemy.java
+++ b/src/Enemies/DinosaurEnemy.java
@@ -152,23 +152,23 @@ public class DinosaurEnemy extends Enemy {
     public HashMap<String, Frame[]> loadAnimations(SpriteSheet spriteSheet) {
         return new HashMap<String, Frame[]>() {{
             put("WALK_LEFT", new Frame[]{
-                    new FrameBuilder(spriteSheet.getSprite(0, 0), 200)
+                    new FrameBuilder(spriteSheet.getSprite(0, 0), 14)
                             .withScale(3)
                             .withBounds(4, 2, 5, 13)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(0, 1), 200)
+                    new FrameBuilder(spriteSheet.getSprite(0, 1), 14)
                             .withScale(3)
                             .withBounds(4, 2, 5, 13)
                             .build()
             });
 
             put("WALK_RIGHT", new Frame[]{
-                    new FrameBuilder(spriteSheet.getSprite(0, 0), 200)
+                    new FrameBuilder(spriteSheet.getSprite(0, 0), 14)
                             .withScale(3)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .withBounds(4, 2, 5, 13)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(0, 1), 200)
+                    new FrameBuilder(spriteSheet.getSprite(0, 1), 14)
                             .withScale(3)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .withBounds(4, 2, 5, 13)

--- a/src/Engine/Config.java
+++ b/src/Engine/Config.java
@@ -6,7 +6,7 @@ import java.awt.*;
 
 /*
  * This class holds some constants like window width/height and resource folder locations
- * Tweak these as needed, they shouldn't break anything (keyword shouldn't).
+ * Tweak these as needed prior to running the application
  */
 public class Config {
     public static final int TARGET_FPS = 60;
@@ -16,6 +16,6 @@ public class Config {
     public static final int GAME_WINDOW_HEIGHT = 605;
     public static final Color TRANSPARENT_COLOR = Colors.MAGENTA;
 
-    // prevents Config from being instantiated -- it's my way of making a "static" class like C# has
+    // prevents Config from being instantiated
     private Config() { }
 }

--- a/src/EnhancedMapTiles/EndLevelBox.java
+++ b/src/EnhancedMapTiles/EndLevelBox.java
@@ -30,15 +30,15 @@ public class EndLevelBox extends EnhancedMapTile {
     public HashMap<String, Frame[]> loadAnimations(SpriteSheet spriteSheet) {
         return new HashMap<String, Frame[]>() {{
             put("DEFAULT", new Frame[] {
-                new FrameBuilder(spriteSheet.getSprite(0, 0), 500)
+                new FrameBuilder(spriteSheet.getSprite(0, 0), 40)
                         .withScale(3)
                         .withBounds(1, 1, 14, 14)
                         .build(),
-                new FrameBuilder(spriteSheet.getSprite(0, 1), 500)
+                new FrameBuilder(spriteSheet.getSprite(0, 1), 40)
                         .withScale(3)
                         .withBounds(1, 1, 14, 14)
                         .build(),
-                new FrameBuilder(spriteSheet.getSprite(0, 2), 500)
+                new FrameBuilder(spriteSheet.getSprite(0, 2), 40)
                         .withScale(3)
                         .withBounds(1, 1, 14, 14)
                         .build()

--- a/src/EnhancedMapTiles/HorizontalMovingPlatform.java
+++ b/src/EnhancedMapTiles/HorizontalMovingPlatform.java
@@ -87,7 +87,6 @@ public class HorizontalMovingPlatform extends EnhancedMapTile {
 
     public void draw(GraphicsHandler graphicsHandler) {
         super.draw(graphicsHandler);
-        //super.drawBounds(graphicsHandler, new Color(0, 0, 255, 100));
     }
 
 }

--- a/src/GameObject/AnimatedSprite.java
+++ b/src/GameObject/AnimatedSprite.java
@@ -2,7 +2,6 @@ package GameObject;
 
 import Engine.GraphicsHandler;
 import Utils.Point;
-import Utils.Stopwatch;
 
 import java.awt.*;
 import java.util.HashMap;
@@ -35,8 +34,8 @@ public class AnimatedSprite implements IntersectableRectangle {
 	// this is essential for the class, as it uses this to be treated as "one sprite"
 	protected Frame currentFrame;
 
-	// times frame delay before transitioning into the next frame of an animation
-	private Stopwatch frameTimer = new Stopwatch();
+	// frame delay before transitioning into the next frame of an animation
+	private int frameDelayCounter;
 
 	public AnimatedSprite(SpriteSheet spriteSheet, float x, float y, String startingAnimationName) {
 		this.x = x;
@@ -79,22 +78,23 @@ public class AnimatedSprite implements IntersectableRectangle {
 		if (!previousAnimationName.equals(currentAnimationName)) {
 			currentFrameIndex = 0;
 			updateCurrentFrame();
-			frameTimer.setWaitTime(getCurrentFrame().getDelay());
+			frameDelayCounter = getCurrentFrame().getDelay();
 			hasAnimationLooped = false;
 		} else {
 			// if animation has more than one frame, check if it's time to transition to a new frame based on that frame's delay
 			if (getCurrentAnimation().length > 1 && currentFrame.getDelay() > 0) {
+				frameDelayCounter--;
 
-				// if enough time has passed based on current frame's delay and it's time to transition to a new frame,
+				// if enough frames have passed based on current frame's delay and it's time to transition to a new frame,
 				// update frame index to the next frame
 				// It will also wrap around back to the first frame index if it was already on the last frame index (the animation will loop)
-				if (frameTimer.isTimeUp()) {
+				if (frameDelayCounter == 0) {
 					currentFrameIndex++;
 					if (currentFrameIndex >= animations.get(currentAnimationName).length) {
 						currentFrameIndex = 0;
 						hasAnimationLooped = true;
 					}
-					frameTimer.setWaitTime(getCurrentFrame().getDelay());
+					frameDelayCounter = getCurrentFrame().getDelay();
 					updateCurrentFrame();
 				}
 			}

--- a/src/Players/Cat.java
+++ b/src/Players/Cat.java
@@ -52,41 +52,41 @@ public class Cat extends Player {
             });
 
             put("WALK_RIGHT", new Frame[] {
-                    new FrameBuilder(spriteSheet.getSprite(1, 0), 200)
+                    new FrameBuilder(spriteSheet.getSprite(1, 0), 14)
                             .withScale(3)
                             .withBounds(8, 9, 8, 9)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(1, 1), 200)
+                    new FrameBuilder(spriteSheet.getSprite(1, 1), 14)
                             .withScale(3)
                             .withBounds(8, 9, 8, 9)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(1, 2), 200)
+                    new FrameBuilder(spriteSheet.getSprite(1, 2), 14)
                             .withScale(3)
                             .withBounds(8, 9, 8, 9)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(1, 3), 200)
+                    new FrameBuilder(spriteSheet.getSprite(1, 3), 14)
                             .withScale(3)
                             .withBounds(8, 9, 8, 9)
                             .build()
             });
 
             put("WALK_LEFT", new Frame[] {
-                    new FrameBuilder(spriteSheet.getSprite(1, 0), 200)
+                    new FrameBuilder(spriteSheet.getSprite(1, 0), 14)
                             .withScale(3)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .withBounds(8, 9, 8, 9)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(1, 1), 200)
+                    new FrameBuilder(spriteSheet.getSprite(1, 1), 14)
                             .withScale(3)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .withBounds(8, 9, 8, 9)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(1, 2), 200)
+                    new FrameBuilder(spriteSheet.getSprite(1, 2), 14)
                             .withScale(3)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .withBounds(8, 9, 8, 9)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(1, 3), 200)
+                    new FrameBuilder(spriteSheet.getSprite(1, 3), 14)
                             .withScale(3)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .withBounds(8, 9, 8, 9)
@@ -139,10 +139,10 @@ public class Cat extends Player {
             });
 
             put("DEATH_RIGHT", new Frame[] {
-                    new FrameBuilder(spriteSheet.getSprite(5, 0), 100)
+                    new FrameBuilder(spriteSheet.getSprite(5, 0), 8)
                             .withScale(3)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(5, 1), 100)
+                    new FrameBuilder(spriteSheet.getSprite(5, 1), 8)
                             .withScale(3)
                             .build(),
                     new FrameBuilder(spriteSheet.getSprite(5, 2), -1)
@@ -151,11 +151,11 @@ public class Cat extends Player {
             });
 
             put("DEATH_LEFT", new Frame[] {
-                    new FrameBuilder(spriteSheet.getSprite(5, 0), 100)
+                    new FrameBuilder(spriteSheet.getSprite(5, 0), 8)
                             .withScale(3)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .build(),
-                    new FrameBuilder(spriteSheet.getSprite(5, 1), 100)
+                    new FrameBuilder(spriteSheet.getSprite(5, 1), 8)
                             .withScale(3)
                             .withImageEffect(ImageEffect.FLIP_HORIZONTAL)
                             .build(),

--- a/src/Tilesets/CommonTileset.java
+++ b/src/Tilesets/CommonTileset.java
@@ -53,10 +53,10 @@ public class CommonTileset extends Tileset {
 
         // sun
         Frame[] sunFrames = new Frame[]{
-                new FrameBuilder(getSubImage(2, 0), 400)
+                new FrameBuilder(getSubImage(2, 0), 50)
                         .withScale(tileScale)
                         .build(),
-                new FrameBuilder(getSubImage(2, 1), 400)
+                new FrameBuilder(getSubImage(2, 1), 50)
                         .withScale(tileScale)
                         .build()
         };
@@ -120,16 +120,16 @@ public class CommonTileset extends Tileset {
 
         // yellow flower
         Frame[] yellowFlowerFrames = new Frame[] {
-                new FrameBuilder(getSubImage(1, 2), 500)
+                new FrameBuilder(getSubImage(1, 2), 65)
                         .withScale(tileScale)
                         .build(),
-                new FrameBuilder(getSubImage(1, 3), 500)
+                new FrameBuilder(getSubImage(1, 3), 65)
                         .withScale(tileScale)
                         .build(),
-                new FrameBuilder(getSubImage(1, 2), 500)
+                new FrameBuilder(getSubImage(1, 2), 65)
                         .withScale(tileScale)
                         .build(),
-                new FrameBuilder(getSubImage(1, 4), 500)
+                new FrameBuilder(getSubImage(1, 4), 65)
                         .withScale(tileScale)
                         .build()
         };
@@ -140,16 +140,16 @@ public class CommonTileset extends Tileset {
 
         // purple flower
         Frame[] purpleFlowerFrames = new Frame[] {
-                new FrameBuilder(getSubImage(0, 3), 500)
+                new FrameBuilder(getSubImage(0, 3), 65)
                         .withScale(tileScale)
                         .build(),
-                new FrameBuilder(getSubImage(0, 4), 500)
+                new FrameBuilder(getSubImage(0, 4), 65)
                         .withScale(tileScale)
                         .build(),
-                new FrameBuilder(getSubImage(0, 3), 500)
+                new FrameBuilder(getSubImage(0, 3), 65)
                         .withScale(tileScale)
                         .build(),
-                new FrameBuilder(getSubImage(0, 5), 500)
+                new FrameBuilder(getSubImage(0, 5), 65)
                         .withScale(tileScale)
                         .build()
         };


### PR DESCRIPTION
Now that I am no longer using Java Swing's Timer class for the game loop, animation delay time needed to be changed from milliseconds passed (in real time) to the number of frames that have passed. This way the game's animations run for the same amount of "game time" regardless of what FPS the game is currently getting.